### PR TITLE
Improve small-screen responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -631,13 +631,65 @@ img {
 }
 
 /************ Banner Css ************/
-/* @media (max-width: 768px) {
+@media (max-width: 768px) {
+  .mast-grid {
+    flex-direction: column;
+    height: auto;
+    padding: 60px 20px;
+  }
 
-} */
+  .mast-left,
+  .mast-right {
+    max-width: 100%;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+
+  /* Projects layout */
+  .projects-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    height: auto;
+    padding: 2rem 1rem;
+  }
+
+  .project-card {
+    position: relative;
+    top: auto;
+    left: auto;
+    transform: none;
+    margin: 1rem;
+  }
+
+  /* Skills section */
+  .skill {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .skill-bx {
+    margin-top: -30px;
+    padding: 40px 30px;
+  }
+}
 
 /* Further adjustments for small devices (phones) */
-/* @media (max-width: 480px) {
-} */
+@media (max-width: 480px) {
+  .mast-grid {
+    padding: 40px 10px;
+    height: auto;
+    max-height: none;
+  }
+
+  .button-home {
+    width: 60px;
+    height: 60px;
+    font-size: 40px;
+  }
+}
 
 /************ Skills Css ************/
 .skill {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders hero heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/software/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add CSS breakpoints to stack banner, project cards, and skills vertically on small screens
- shrink hero button and reset project card positioning for phones
- update test to look for hero heading instead of removed sample text

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6898fd78c4788330bc3c811697948361